### PR TITLE
Add GitHub Actions Workflow for Build & Release, Update Project Metadata, and Publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,21 @@ jobs:
         working-directory: tools/isort-gaussdb
         run: python -m build
 
+      - name: Show dist dirs content
+        run: |
+            ls -l gaussdb/dist/
+            ls -l gaussdb_pool/dist/
+            ls -l tools/isort-gaussdb/dist/
+
       - name: Collect all artifacts
         run: |
           mkdir -p all_dist
           cp gaussdb/dist/* all_dist/
           cp gaussdb_pool/dist/* all_dist/
           cp tools/isort-gaussdb/dist/* all_dist/
+          ls -ltr all_dist/
 
       - name: Upload all dist/* to GitHub Release
         uses: softprops/action-gh-release@v1
+        with:
+          files: all_dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install build tools
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools wheel build
+
+      - name: Build gaussdb
+        working-directory: gaussdb
+        run: python -m build
+
+      - name: Build gaussdb_pool
+        working-directory: gaussdb_pool
+        run: python -m build
+
+      - name: Build isort_gaussdb
+        working-directory: tools/isort-gaussdb
+        run: python -m build
+
+      - name: Collect all artifacts
+        run: |
+          mkdir -p all_dist
+          cp gaussdb/dist/* all_dist/
+          cp gaussdb_pool/dist/* all_dist/
+          cp tools/isort-gaussdb/dist/* all_dist/
+
+      - name: Upload all dist/* to GitHub Release
+        uses: softprops/action-gh-release@v1

--- a/gaussdb/README.rst
+++ b/gaussdb/README.rst
@@ -8,7 +8,7 @@ This distribution contains the pure Python package ``gaussdb``.
 .. Note::
 
     Despite the lack of number in the package name, this package is the
-    successor of psycopg2_.
+    successor of psycopg2.
 
     Please use the _GaussDB package if you are maintaining an existing program
     using _GaussDB as a dependency. If you are developing something new,

--- a/gaussdb/pyproject.toml
+++ b/gaussdb/pyproject.toml
@@ -4,14 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaussdb"
-description = "PostgreSQL database adapter for Python"
+description = "GaussDB database adapter for Python"
 
 # STOP AND READ! if you change:
-version = "1.0.0.dev1"
+version = "1.0.0.dev2"
 # also change:
 # - `docs/news.rst` to declare this as the current version or an unreleased one;
 # - `gaussdb_c/pyproject.toml` to the same version;
-# - the `c ` and `binary` "optional-dependencies" below to the same version.
 #
 # NOTE: you can use `tools/bump_version.py` to maintain versions.
 
@@ -49,23 +48,17 @@ email = "daniele.varrazzo@gmail.com"
 text = "GNU Lesser General Public License v3 (LGPLv3)"
 
 [project.urls]
-Homepage = "https://gaussdb.org/"
-Documentation = "https://gaussdb.org/gaussdb/docs/"
-Changes = "https://gaussdb.org/gaussdb/docs/news.html"
-Code = "https://github.com/gaussdb/gaussdb"
-"Issue Tracker" = "https://github.com/gaussdb/gaussdb/issues"
+Homepage = "https://psycopg.org/"
+Documentation = "https://psycopg.org/psycopg3/docs/"
+Changes = "https://psycopg.org/psycopg3/docs/news.html"
+Code = "https://github.com/psycopg/psycopg"
+"Issue Tracker" = "https://github.com/psycopg/psycopg/issues"
 
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
 
 [project.optional-dependencies]
-c = [
-    "gaussdb-c == 1.0.0.dev1; implementation_name != \"pypy\"",
-]
-binary = [
-    "gaussdb-binary == 1.0.0.dev1; implementation_name != \"pypy\"",
-]
 pool = [
     "gaussdb-pool",
 ]

--- a/gaussdb_pool/pyproject.toml
+++ b/gaussdb_pool/pyproject.toml
@@ -44,11 +44,11 @@ email = "daniele.varrazzo@gmail.com"
 text = "GNU Lesser General Public License v3 (LGPLv3)"
 
 [project.urls]
-Homepage = "https://gaussdb.org/"
-Documentation = "https://www.gaussdb.org/gaussdb/docs/advanced/pool.html"
-Changes = "https://gaussdb.org/gaussdb/docs/news_pool.html"
-Code = "https://github.com/gaussdb/gaussdb"
-"Issue Tracker" = "https://github.com/gaussdb/gaussdb/issues"
+Homepage = "https://psycopg.org/"
+Documentation = "https://www.psycopg.org/psycopg3/docs/advanced/pool.html"
+Changes = "https://psycopg.org/psycopg3/docs/news_pool.html"
+Code = "https://github.com/psycopg/psycopg"
+"Issue Tracker" = "https://github.com/psycopg/psycopg/issues"
 
 [project.readme]
 file = "README.rst"

--- a/tools/isort-gaussdb/README.rst
+++ b/tools/isort-gaussdb/README.rst
@@ -26,4 +26,4 @@ Note: because this is the first day I use isort at all, there is a chance that
 this plug-in is totally useless and the same can be done using isort features.
 
 .. _isort: https://pycqa.github.io/isort/
-.. _gaussdb 3: https://www.gaussdb.org/
+.. _gaussdb: https://www.huaweicloud.com/product/gaussdb.html


### PR DESCRIPTION
## Description
This PR introduces a GitHub Actions workflow to automate the build and release process for the `gaussdb`, `gaussdb-pool`, and `isort-gaussdb` packages. It updates project metadata in `pyproject.toml` and `README.rst` files to correct URLs, descriptions, and version numbers. Additionally, the packages have been successfully published to PyPI, making them available for installation via `pip`. The changes streamline the release process, improve documentation consistency, and ensure accessibility via PyPI.

## Changes Made
- **Added GitHub Actions Workflow** (`release.yml`):
  - Created `.github/workflows/release.yml` to automate building and releasing wheel files for `gaussdb`, `gaussdb-pool`, and `isort-gaussdb`.
  - Triggers on tags matching `v*.*.*` (e.g., `v1.0.0.dev2`).
  - Steps include:
    - Checking out the source code.
    - Setting up Python 3.9.
    - Installing build tools (`setuptools`, `wheel`, `build`).
    - Building wheel files in `gaussdb`, `gaussdb_pool`, and `tools/isort-gaussdb` directories.
    - Collecting artifacts into `all_dist/`.
    - Uploading wheels to GitHub Releases using `softprops/action-gh-release@v1`.
- **Updated `gaussdb/pyproject.toml`**:
  - Changed version from `1.0.0.dev1` to `1.0.0.dev2`.
  - Updated description to "GaussDB database adapter for Python".
  - Corrected project URLs to `psycopg.org` instead of `gaussdb.org`.
  - Removed outdated optional dependencies (`gaussdb-c`, `gaussdb-binary`).
  - Removed version synchronization comments, assuming `tools/bump_version.py` is used.
- **Updated `gaussdb_pool/pyproject.toml`**:
  - Updated project URLs to `psycopg.org` for consistency.
- **Updated `gaussdb/README.rst`**:
  - Fixed typo: changed "successor of psycopg2_" to "successor of psycopg2".
- **Updated `tools/isort-gaussdb/README.rst`**:
  - Updated GaussDB link to `https://www.huaweicloud.com/product/gaussdb.html`.
- **Published to PyPI**:
  - Uploaded packages to PyPI:
    - [gaussdb](https://pypi.org/project/gaussdb/)
    - [gaussdb-pool](https://pypi.org/project/gaussdb-pool/)
    - [isort-gaussdb](https://pypi.org/project/isort-gaussdb/)

## Why
- **Automation**: The GitHub Actions workflow automates building and releasing wheel files, reducing manual effort and ensuring consistency.
- **Versioning**: Bumping `gaussdb` to `1.0.0.dev2` reflects ongoing development and aligns with the latest changes.
- **Consistency**: Updating URLs to `psycopg.org` aligns with the upstream `psycopg3` project (as these packages appear to be forks or rebrands). The Huawei Cloud GaussDB link in `isort-gaussdb` points to the correct product page.
- **Documentation**: Fixing typos and updating descriptions improves clarity for users and developers.
- **PyPI Availability**: Publishing to PyPI makes the packages easily accessible to users via `pip install`, simplifying installation.
- **Cleanup**: Removing outdated dependencies and comments streamlines configuration and encourages use of `tools/bump_version.py`.

## Testing
- **Local Testing**:
  - Built packages locally using `python -m build` in `gaussdb`, `gaussdb_pool`, and `tools/isort-gaussdb`.
  - Verified wheel files (`*.whl`) were generated in `dist/` directories.
  - Installed wheels in a Python 3.9 virtual environment:
    ```bash
    python3 -m venv test_env
    source test_env/bin/activate
    pip install --upgrade pip
    pip install gaussdb-1.0.0.dev2-py3-none-any.whl gaussdb_pool-1.0.0.dev1-py3-none-any.whl isort_gaussdb-0.0.1-py3-none-any.whl --no-index
    python -c "import gaussdb; print(gaussdb.__version__)"  # Outputs: 1.0.0.dev2
    ```
  - Confirmed imports for `gaussdb_pool` and `isort_gaussdb`.
- **PyPI Installation**:
  - Tested installation from PyPI:
    ```bash
    python3 -m venv test_env
    source test_env/bin/activate
    pip install --upgrade pip
    pip install isort-gaussdb
    pip install gaussdb
    pip install gaussdb-pool
    python -c "import gaussdb; print(gaussdb.__version__)"  # Outputs: 1.0.0.dev2
    ```
  - Verified all packages import correctly and function as expected.
- **Workflow Testing**:
  - Pushed a test tag (`v1.0.0.dev2-test`) to a test branch to trigger the workflow.
  - Confirmed the workflow:
    - Built wheels for all three packages.
    - Collected artifacts in `all_dist/`.
    - Uploaded wheels to a draft GitHub Release.
  - Checked workflow logs for errors and verified artifacts on the release page.
- **ARM Compatibility** (EulerOS, `aarch64`):
  - Tested installation on EulerOS (ARM) using Python 3.9.
  - Confirmed `py3-none-any` wheels are compatible and install correctly from both local files and PyPI.
- **Documentation**:
  - Verified updated URLs (`psycopg.org`, `huaweicloud.com`) are accessible.
  - Checked `README.rst` renders correctly with updated text.

## Additional Notes
- **PyPI Publication**:
  - The packages are now available on PyPI at:
    - [gaussdb](https://pypi.org/project/gaussdb/)
    - [gaussdb-pool](https://pypi.org/project/gaussdb-pool/)
    - [isort-gaussdb](https://pypi.org/project/isort-gaussdb/)
  - Users can install them using the provided instructions.
- **Versioning**: Ensure `tools/bump_version.py` is used for future version updates to maintain consistency across `pyproject.toml` files.
- **GaussDB vs. Psycopg**: The packages appear to be forks or rebrands of `psycopg3`. Consider clarifying this relationship in the repository description or documentation.
- **x86_64/ARM Support**: The `py3-none-any` wheels are platform-independent, suitable for EulerOS (x86_64/ARM). If native extensions are added later, ensure x86_64/ARM compatibility.
- **Previous Issues**: Earlier installations had issues with external paths (`/opt/gaussdb_driver`) and `--extra-index-url` warnings. Using `--no-index` for local installs or PyPI avoids these. Run `pip config unset global.extra-index-url` if warnings persist.
- **Usage Instructions**:
  To install the packages from PyPI:
  ```bash
  python3 -m venv myvenv
  source myvenv/bin/activate
  pip install --upgrade pip
  pip install isort-gaussdb
  pip install gaussdb
  pip install gaussdb-pool
  ```

## Release Commands
To create and push a release tag for `v1.0.0.dev2`:

```bash
git tag v1.0.0.dev2
git push origin v1.0.0.dev2
```

This triggers the `Build and Release` workflow, building and uploading the wheels to a GitHub Release. The wheels are already published to PyPI, so no additional PyPI upload is needed unless further changes are made.