### PR TITLE
Add Demo and Update Database Compatibility Mode to Default Mode A

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,9 @@ Installation from PyPI:
     pip install gaussdb-pool
     python -c "import gaussdb; print(gaussdb.__version__)"  # Outputs: 1.0.0.dev2
 
+    # Run demo
+    python ./example/demo.py
+
 You can also clone this repository to develop GaussDB::
 
     # Create a new Python virtual environment in the .venv directory
@@ -111,8 +114,8 @@ Please add ``--config-settings editable_mode=strict`` to the ``pip install
 
 Now hack away! You can run the tests using on GaussDB::
 
-    # Create a new database named "test" with PostgreSQL compatibility enabled
-    gsql -c 'CREATE DATABASE test DBCOMPATIBILITY 'PG' ;'
+    # Create a new database named "test" with Default compatibility with Oracle enabled
+    gsql -c 'CREATE DATABASE test;'
 
     # Set the Python import path to include your local GaussDB Python project
     # Replace your_path with actual values
@@ -154,8 +157,8 @@ Recommended Steps to Run OpenGauss with Python GaussDB Driver Testing (Assuming 
     # Connect to the OpenGauss database using the gsql client
     gsql -d postgres -p 5432 -U omm
 
-    -- Create a new database named "test" with PostgreSQL compatibility enabled
-    CREATE DATABASE test DBCOMPATIBILITY 'PG';
+    -- Create a new database named "test" with Default compatibility with Oracle enabled
+    CREATE DATABASE test;
 
 
     # Set the Python import path to include your local GaussDB Python project

--- a/example/demo.py
+++ b/example/demo.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+from gaussdb import connect
+
+os.environ["GAUSSDB_IMPL"] = "python"
+
+
+def main():
+    dsn = os.environ.get("GAUSSDB_TEST_DSN")
+    if not dsn:
+        print("❌ Please set the GAUSSDB_TEST_DSN environment variable, for example:")
+        print(
+            '   export GAUSSDB_TEST_DSN="dbname=test01 user=root password=***'
+            'host=** port=8000"'
+        )
+        sys.exit(1)
+
+    drop_table_sql = "DROP TABLE IF EXISTS test"
+    create_table_sql = (
+        "CREATE TABLE test (id serial PRIMARY KEY, num integer, data text)"
+    )
+    insert_data_sql = "INSERT INTO test (num, data) VALUES (%s, %s)"
+    update_data_sql = "UPDATE test SET data = 'gaussdb' WHERE num = 2"
+    select_sql = "SELECT * FROM test"
+
+    with connect(dsn, connect_timeout=10, application_name="gaussdb-demo") as conn:
+
+        with conn.cursor() as cur:
+            server_version = conn.execute("select version()").fetchall()[0][0]
+            print(f"✅ Connected. Server version: {server_version}")
+            print(f"Vendor: {conn.info.vendor}, Version: {conn.info.server_version}")
+
+            cur.execute(drop_table_sql)
+            cur.execute(create_table_sql)
+            cur.execute(insert_data_sql, (1, "hello"))
+            cur.execute(insert_data_sql, (2, "world"))
+
+            cur.execute(select_sql)
+            print("📄origin: ", cur.fetchall())
+
+            cur.execute(update_data_sql)
+            cur.execute(select_sql)
+            print("📄update: ", cur.fetchall())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR introduces a demo script for the GaussDB Python driver and updates the database compatibility mode to default mode A (Oracle compatibility). The changes include:
1. Adding a demo script (`example/demo.py`) to demonstrate basic database operations (create, insert, update, select).
2. Updating the `README.rst` to include instructions for running the demo and revising the database compatibility mode from PostgreSQL to default Oracle compatibility mode A.

## Changes
- **Added Demo Script**:
  - File: `example/demo.py`
  - A new Python script that connects to a GaussDB database, creates a table, inserts data, updates it, and queries the results.
  - Uses environment variable `GAUSSDB_TEST_DSN` for connection settings.
- **Updated README**:
  - File: `README.rst`
  - Added instructions to run the demo script (`python ./example/demo.py`).
  - Revised database creation instructions to use default compatibility mode A (Oracle) instead of PostgreSQL compatibility.

## Details
### Demo Script
- Location: `example/demo.py`
- Functionality:
  - Connects to a GaussDB database using the provided DSN.
  - Drops existing table (if any), creates a new table (`test`), inserts sample data, updates a record, and queries the table.
  - Prints server version and vendor information for verification.
- Requires `GAUSSDB_TEST_DSN` environment variable for database connection details.

### README Updates
- Added demo run instructions at line 55.
- Changed database creation command from `CREATE DATABASE test DBCOMPATIBILITY 'PG'` to `CREATE DATABASE test` to use default Oracle compatibility mode A.

## Testing
- Verified the demo script (`example/demo.py`) successfully connects to a GaussDB database, performs CRUD operations, and outputs results as expected.
- Confirmed the updated `README.rst` instructions accurately reflect the default compatibility mode A and demo execution steps.
- Tested database creation with default mode A using `gsql -c 'CREATE DATABASE test;'`.