### PR TITLE
Add SQLAlchemy dialect adapter + Python 3.7+ support

### DIFF
--- a/gaussdb/gaussdb/_oids.py
+++ b/gaussdb/gaussdb/_oids.py
@@ -5,6 +5,7 @@ This is an internal module. Types are publicly exposed by
 `gaussdb.gaussdb_.types`. This module is only used to know the OIDs at import
 time and avoid circular import problems.
 """
+from __future__ import annotations
 
 # Copyright (C) 2020 The Psycopg Team
 

--- a/gaussdb/gaussdb/_tz.py
+++ b/gaussdb/gaussdb/_tz.py
@@ -7,8 +7,13 @@ Timezone utility functions.
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import timezone, tzinfo
-from zoneinfo import ZoneInfo
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+else:
+    from backports.zoneinfo import ZoneInfo
 
 from .pq.abc import PGconn
 

--- a/gaussdb/pyproject.toml
+++ b/gaussdb/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -34,9 +36,11 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.7"
 dependencies = [
-    "typing-extensions >= 4.6; python_version < '3.13'",
+    "typing-extensions >= 4.6, < 4.8; python_version < '3.8'",
+    "typing-extensions >= 4.6; python_version >= '3.8' and python_version < '3.13'",
+    "backports.zoneinfo >= 0.2.1; python_version < '3.9'",
     "tzdata; sys_platform == 'win32'",
 ]
 

--- a/gaussdb_sqlalchemy/README.md
+++ b/gaussdb_sqlalchemy/README.md
@@ -1,0 +1,50 @@
+# GaussDB SQLAlchemy Dialect
+
+SQLAlchemy dialect for Huawei GaussDB, built on the `gaussdb` (psycopg3 fork) driver.
+
+## 前置条件
+
+- Python 3.7+
+- GaussDB libpq (Linux: 运行 `tools/install_gaussdb_driver.sh`)
+- `gaussdb` Python 包 (psycopg3 fork)
+
+## 安装
+
+```bash
+pip install gaussdb-sqlalchemy
+```
+
+## 连接
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine(
+    "gaussdb://user:password@host:port/dbname?sslmode=disable"
+)
+```
+
+也支持显式指定驱动：
+
+```python
+engine = create_engine(
+    "gaussdb+psycopg://user:password@host:port/dbname?sslmode=disable"
+)
+```
+
+## 兼容模式
+
+驱动自动检测数据库的兼容模式并适配 SQL 方言：
+
+| 特性 | A 兼容 (Oracle) | B 兼容 (MySQL) | M 兼容 (MySQL) |
+|------|----------------|----------------|----------------|
+| 标识符引号 | 双引号 | 双引号/反引号 | 反引号 |
+| 自增主键 | serial | serial/AUTO_INCREMENT | AUTO_INCREMENT |
+| ORM INSERT 获取自增 ID | RETURNING | RETURNING | LAST_INSERT_ID() |
+| 字符串拼接 | \|\| | \|\| | CONCAT() |
+| TIMESTAMP 精度 | 默认无 | 默认无 | TIMESTAMP(6) |
+| Oracle 语法 (DUAL/NVL/SYSDATE) | 支持 | 支持 | 不支持 |
+
+## 许可证
+
+LGPL-3.0

--- a/gaussdb_sqlalchemy/__init__.py
+++ b/gaussdb_sqlalchemy/__init__.py
@@ -1,0 +1,15 @@
+"""
+SQLAlchemy dialect for Huawei GaussDB, built on the gaussdb (psycopg3 fork) driver.
+
+Supports A (Oracle), B (MySQL), and M (MySQL) compatibility modes.
+"""
+from __future__ import annotations
+
+from .base import GaussDBDialect, register_dialect
+from .alembic import register_alembic_impl
+
+register_dialect()
+register_alembic_impl()
+
+__all__ = ["GaussDBDialect"]
+__version__ = "0.1.0"

--- a/gaussdb_sqlalchemy/alembic.py
+++ b/gaussdb_sqlalchemy/alembic.py
@@ -1,0 +1,49 @@
+"""
+Alembic integration for GaussDB SQLAlchemy dialect.
+
+Registers an Alembic implementation that handles M-compat (MySQL) mode
+differences in ALTER TABLE syntax.
+"""
+from __future__ import annotations
+
+
+def register_alembic_impl():
+    """Register GaussDB-specific Alembic implementation."""
+    try:
+        from alembic.ddl import postgresql as pg_impl
+        from alembic.ddl.base import ColumnType, ColumnNullable, ColumnDefault
+        from sqlalchemy.ext.compiler import compiles
+
+        # M-compat: ALTER COLUMN ... TYPE → MODIFY COLUMN
+        @compiles(ColumnType, "gaussdb")
+        def _gaussdb_column_type(element, compiler, **kw):
+            from gaussdb_sqlalchemy.base import GaussDBDialect
+
+            dialect = kw.get("dialect")
+            compat = getattr(dialect, "gaussdb_compatibility", None) if dialect else None
+
+            if compat == "M":
+                table_name = compiler.preparer.quote(element.table_name)
+                col_name = compiler.preparer.quote(element.column_name)
+                col_type = element.column.type
+                type_text = dialect.type_compiler_instance.process(col_type) if dialect else ""
+                return f"ALTER TABLE {table_name} MODIFY COLUMN {col_name} {type_text}"
+
+            return pg_impl.visit_column_type(element, compiler, **kw)
+
+        @compiles(ColumnNullable, "gaussdb")
+        def _gaussdb_column_nullable(element, compiler, **kw):
+            dialect = kw.get("dialect")
+            compat = getattr(dialect, "gaussdb_compatibility", None) if dialect else None
+
+            if compat == "M":
+                table_name = compiler.preparer.quote(element.table_name)
+                col_name = compiler.preparer.quote(element.column_name)
+                null_spec = "NULL" if element.existing_nullable else "NOT NULL"
+                return f"ALTER TABLE {table_name} MODIFY COLUMN {col_name} {null_spec}"
+
+            return pg_impl.visit_column_nullable(element, compiler, **kw)
+
+    except ImportError:
+        # Alembic not installed
+        pass

--- a/gaussdb_sqlalchemy/base.py
+++ b/gaussdb_sqlalchemy/base.py
@@ -1,0 +1,362 @@
+"""
+SQLAlchemy dialect for GaussDB using the gaussdb (psycopg3 fork) DBAPI.
+
+This dialect connects to GaussDB via the gaussdb Python package (a fork of
+psycopg3 that uses libpq).  It auto-detects the database compatibility mode
+(A=Oracle, B=MySQL, M=MySQL) and adapts SQL generation accordingly.
+"""
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.dialects.postgresql.base import (
+    PGDialect,
+    PGDDLCompiler,
+    PGTypeCompiler,
+    PGIdentifierPreparer,
+    PGExecutionContext,
+    PGCompiler,
+)
+from sqlalchemy import schema as sa_schema
+from sqlalchemy import types as sqltypes
+from sqlalchemy import text
+from sqlalchemy.sql import expression
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.compiler import OPERATORS
+from sqlalchemy.engine import reflection
+
+# ── compatibility detection ──────────────────────────────────────────────────
+
+_COMPAT_CACHE: dict[str, str] = {}
+
+
+def _detect_compatibility(connection) -> str:
+    """Return 'A', 'B', or 'M' based on datcompatibility."""
+    cache_key = str(connection.engine.url)
+    if cache_key in _COMPAT_CACHE:
+        return _COMPAT_CACHE[cache_key]
+    try:
+        row = connection.execute(
+            text(
+                "select datcompatibility from pg_database "
+                "where datname = current_database()"
+            )
+        ).scalar_one()
+        compat = str(row).strip().upper()[:1]
+        if compat not in ("A", "B", "M", "P"):
+            compat = "A"
+        if compat == "P":  # 'pg' mode → treat as A
+            compat = "A"
+    except Exception:
+        compat = "A"
+    _COMPAT_CACHE[cache_key] = compat
+    return compat
+
+
+# ── Type compiler ────────────────────────────────────────────────────────────
+
+
+class GaussDBTypeCompiler(PGTypeCompiler):
+    """Adjust DDL type generation for M-compat (MySQL) mode."""
+
+    def visit_TIMESTAMP(self, type_, **kw):
+        compat = self.dialect.gaussdb_compatibility
+        if compat == "M":
+            # M mode: always emit TIMESTAMP(6) for microsecond precision
+            return "TIMESTAMP(6)"
+        return super().visit_TIMESTAMP(type_, **kw)
+
+    def visit_large_binary(self, type_, **kw):
+        compat = self.dialect.gaussdb_compatibility
+        if compat == "M":
+            return "BLOB"
+        return super().visit_large_binary(type_, **kw)
+
+
+# ── DDL compiler ─────────────────────────────────────────────────────────────
+
+
+class GaussDBDDLCompiler(PGDDLCompiler):
+    """Adjust DDL for M-compat (MySQL) mode."""
+
+    def get_column_specification(self, column, **kw):
+        compat = self.dialect.gaussdb_compatibility
+        # M mode: INTEGER AUTO_INCREMENT instead of SERIAL for PK
+        if compat == "M" and column.autoincrement and column.primary_key:
+            if isinstance(column.type, sqltypes.Integer):
+                coltype = self.dialect.type_compiler_instance.process(
+                    sqltypes.Integer()
+                )
+                default = " AUTO_INCREMENT"
+                colname = self.preparer.quote(column.name)
+                return f"{colname} {coltype} NOT NULL{default}"
+        return super().get_column_specification(column, **kw)
+
+    def visit_create_table(self, create, **kw):
+        return super().visit_create_table(create, **kw)
+
+    def visit_column(self, column, **kw):
+        compat = self.dialect.gaussdb_compatibility
+        if compat == "M" and column.autoincrement and column.primary_key:
+            if isinstance(column.type, sqltypes.Integer):
+                # Already handled in get_column_specification
+                return self.get_column_specification(column, **kw)
+        return super().visit_column(column, **kw)
+
+    def visit_alter_column(self, alter, **kw):
+        compat = self.dialect.gaussdb_compatibility
+        if compat == "M":
+            return self._visit_alter_column_m(alter, **kw)
+        return super().visit_alter_column(alter, **kw)
+
+    def _visit_alter_column_m(self, alter, **kw):
+        """M-compat ALTER COLUMN uses MODIFY COLUMN syntax."""
+        column = alter.column
+        col_name = self.preparer.quote(column.name)
+
+        if alter.modify_type is not None:
+            col_type = self.dialect.type_compiler_instance.process(
+                alter.modify_type
+            )
+            null_spec = "" if column.nullable else " NOT NULL"
+            return f"ALTER TABLE {self.preparer.quote(alter.table.name)} " \
+                   f"MODIFY COLUMN {col_name} {col_type}{null_spec}"
+
+        if alter.modify_nullable is not None:
+            null_spec = "NULL" if alter.modify_nullable else "NOT NULL"
+            return f"ALTER TABLE {self.preparer.quote(alter.table.name)} " \
+                   f"MODIFY COLUMN {col_name} {null_spec}"
+
+        return super().visit_alter_column(alter, **kw)
+
+
+# ── Identifier preparer ──────────────────────────────────────────────────────
+
+
+class GaussDBIdentifierPreparer(PGIdentifierPreparer):
+    """Use backticks for M-compat (MySQL) mode."""
+
+    def __init__(self, dialect, **kwargs):
+        super().__init__(dialect, **kwargs)
+        compat = getattr(dialect, "gaussdb_compatibility", None)
+        if compat == "M":
+            self.identifier_quote_char = "`"
+            self.reserved_words.update(
+                [
+                    "auto_increment", "engine", "charset", "collate",
+                    "comment", "default", "key", "primary",
+                ]
+            )
+
+
+# ── SQL compiler (concat fix) ────────────────────────────────────────────────
+
+
+class GaussDBCompiler(PGCompiler):
+    """Replace || with CONCAT() in M-compat mode."""
+
+    def visit_expression_clauselist(self, clauselist, **kw):
+        compat = getattr(self.dialect, "gaussdb_compatibility", None)
+        if compat == "M":
+            # Check if this is a concat operation
+            if clauselist.operator is operators.concat_op:
+                return self._m_concat(clauselist, **kw)
+        return super().visit_expression_clauselist(clauselist, **kw)
+
+    def _m_concat(self, clauselist, **kw):
+        args = []
+        for clause in clauselist.clauses:
+            args.append(self.process(clause, **kw))
+        return "CONCAT(" + ", ".join(args) + ")"
+
+
+# ── Execution context (M-compat lastrowid) ───────────────────────────────────
+
+
+class GaussDBMExecutionContext(PGExecutionContext):
+    """Get auto-increment ID via LAST_INSERT_ID() in M-compat mode."""
+
+    def get_lastrowid(self):
+        try:
+            cursor = self.cursor
+            cursor.execute("select last_insert_id()")
+            row = cursor.fetchone()
+            if row and row[0] is not None:
+                val = row[0]
+                # Handle Java BigInteger from JDBC (shouldn't happen with psycopg3)
+                if hasattr(val, "bit_length"):
+                    return int(str(val))
+                return int(val)
+        except Exception:
+            pass
+        return None
+
+
+# ── Dialect ──────────────────────────────────────────────────────────────────
+
+
+class GaussDBDialect(PGDialect):
+    """SQLAlchemy dialect for GaussDB using the gaussdb (psycopg3) DBAPI."""
+
+    # Use psycopg3-style connection
+    driver = "gaussdb"
+    name = "gaussdb"
+
+    ddl_compiler = GaussDBDDLCompiler
+    type_compiler = GaussDBTypeCompiler
+    preparer = GaussDBIdentifierPreparer
+    statement_compiler = GaussDBCompiler
+
+    supports_statement_cache = True
+    supports_native_enum = True
+    supports_native_boolean = True
+    supports_smallserial = True
+    supports_sequences = True
+    sequences_optional = True
+    postfetch_lastrowid = False
+    default_paramstyle = "pyformat"
+
+    # Disable HSTORE (not assumed for lightweight GaussDB)
+    use_native_hstore = False
+    postgresql_compat_version = (9, 2)
+
+    # GaussDB compatibility mode: 'A', 'B', or 'M'
+    gaussdb_compatibility = None
+
+    # Register GaussDB M-compat binary types for reflection
+    ischema_names = dict(PGDialect.ischema_names)
+    ischema_names["blob"] = sqltypes.LargeBinary
+    ischema_names["longblob"] = sqltypes.LargeBinary
+
+    # ── DBAPI ────────────────────────────────────────────────────────────────
+
+    @classmethod
+    def import_dbapi(cls):
+        """Import the gaussdb (psycopg3 fork) DBAPI module."""
+        try:
+            import gaussdb   # noqa: F401
+            import gaussdb.dbapi20  # noqa: F401
+            return gaussdb.dbapi20
+        except ImportError:
+            try:
+                import psycopg
+                import psycopg.dbapi20
+                return psycopg.dbapi20
+            except ImportError:
+                raise ImportError(
+                    "The gaussdb dialect requires the 'gaussdb' package "
+                    "(or 'psycopg' as fallback). "
+                    "Install with: pip install gaussdb"
+                )
+
+    # ── Connection ───────────────────────────────────────────────────────────
+
+    def create_connect_args(self, url):
+        """Convert SQLAlchemy URL to gaussdb connect() kwargs."""
+        opts = url.translate_connect_args(username="user", database="dbname")
+        opts.update(url.query)
+
+        # Remove SQLAlchemy-specific params
+        opts.pop("host", None)
+        opts.pop("port", None)
+        opts.pop("user", None)
+        opts.pop("password", None)
+        opts.pop("dbname", None)
+        opts.pop("database", None)
+
+        # Build conninfo string for gaussdb.connect()
+        parts = []
+        if url.host:
+            parts.append(f"host={url.host}")
+        if url.port:
+            parts.append(f"port={url.port}")
+        if url.username:
+            parts.append(f"user={url.username}")
+        if url.password:
+            parts.append(f"password={url.password}")
+        if url.database:
+            parts.append(f"dbname={url.database}")
+
+        # Pass through extra params (sslmode, etc.)
+        for key, value in opts.items():
+            parts.append(f"{key}={value}")
+
+        conninfo = " ".join(parts)
+        return ([conninfo], {})
+
+    def do_execute(self, cursor, statement, parameters, context=None):
+        cursor.execute(statement, parameters)
+
+    # ── Initialization ───────────────────────────────────────────────────────
+
+    def initialize(self, connection):
+        super().initialize(connection)
+        self.gaussdb_compatibility = _detect_compatibility(connection)
+        self._apply_compatibility_features()
+
+    def _apply_compatibility_features(self):
+        """Apply mode-specific dialect settings."""
+        if self.gaussdb_compatibility == "M":
+            # M mode: no RETURNING, use LAST_INSERT_ID
+            self.insert_returning = False
+            self.postfetch_lastrowid = True
+            self.execution_ctx_cls = GaussDBMExecutionContext
+            # M mode: no native boolean (uses TINYINT)
+            self.supports_native_boolean = False
+        else:
+            self.insert_returning = True
+            self.postfetch_lastrowid = False
+            self.supports_native_boolean = True
+
+    # ── Isolation level ──────────────────────────────────────────────────────
+
+    def set_isolation_level(self, connection, level):
+        compat = self.gaussdb_compatibility
+        if compat == "M":
+            # M mode: COMMIT before SET to avoid transaction conflicts
+            connection.commit()
+            # M mode: no "AS" keyword in SET SESSION CHARACTERISTICS
+            level = level.upper().replace(" ", " ")
+            connection.execute(
+                text(f"SET SESSION TRANSACTION ISOLATION LEVEL {level}")
+            )
+        else:
+            super().set_isolation_level(connection, level)
+
+    # ── Reflection overrides for M-compat ────────────────────────────────────
+
+    @reflection.cache
+    def get_columns(self, connection, table_name, schema=None, **kw):
+        compat = self.gaussdb_compatibility
+        if compat == "M":
+            return self._get_columns_m(connection, table_name, schema, **kw)
+        return super().get_columns(connection, table_name, schema, **kw)
+
+    def _get_columns_m(self, connection, table_name, schema=None, **kw):
+        """M-compat column reflection: map blob→LargeBinary."""
+        columns = super().get_columns(connection, table_name, schema, **kw)
+        for col in columns:
+            type_obj = col["type"]
+            type_str = str(type_obj).lower()
+            # M mode: blob types should be LargeBinary
+            if "bytea" in type_str or "blob" in type_str:
+                col["type"] = sqltypes.LargeBinary()
+        return columns
+
+
+# ── Registration ─────────────────────────────────────────────────────────────
+
+
+def register_dialect():
+    """Register the GaussDB dialect with SQLAlchemy."""
+    from sqlalchemy.dialects import registry
+
+    registry.register(
+        "gaussdb", "gaussdb_sqlalchemy.base", "GaussDBDialect"
+    )
+    registry.register(
+        "gaussdb.psycopg", "gaussdb_sqlalchemy.base", "GaussDBDialect"
+    )
+    registry.register(
+        "gaussdb.gaussdb", "gaussdb_sqlalchemy.base", "GaussDBDialect"
+    )

--- a/gaussdb_sqlalchemy/pyproject.toml
+++ b/gaussdb_sqlalchemy/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["setuptools>=49.2.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaussdb-sqlalchemy"
+version = "0.1.0"
+description = "SQLAlchemy dialect for Huawei GaussDB, built on the gaussdb (psycopg3 fork) driver."
+readme = "README.md"
+requires-python = ">=3.7"
+license = { text = "GNU Lesser General Public License v3 (LGPLv3)" }
+authors = [{ name = "GaussDB Python Driver Contributors" }]
+keywords = ["gaussdb", "sqlalchemy", "database", "driver", "dialect"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+    "Operating System :: POSIX",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "SQLAlchemy>=2.0,<2.2",
+    "gaussdb>=1.0.4",
+]
+
+[project.optional-dependencies]
+alembic = [
+    "alembic>=1.13",
+]
+test = [
+    "alembic>=1.13",
+    "pytest>=6.2.5",
+]
+
+[project.urls]
+Homepage = "https://github.com/jarrenL/gaussdb-python"
+
+[project.entry-points."sqlalchemy.dialects"]
+gaussdb = "gaussdb_sqlalchemy.base:GaussDBDialect"
+"gaussdb.psycopg" = "gaussdb_sqlalchemy.base:GaussDBDialect"
+"gaussdb.gaussdb" = "gaussdb_sqlalchemy.base:GaussDBDialect"
+
+[tool.setuptools]
+packages = ["gaussdb_sqlalchemy"]


### PR DESCRIPTION
## 新增内容

### 1. SQLAlchemy 方言适配包 (gaussdb_sqlalchemy/)
- base.py: GaussDBDialect, A/B/M 兼容模式自动检测和适配
  - M 模式: AUTO_INCREMENT, TIMESTAMP(6), CONCAT(), 反引号, LAST_INSERT_ID
  - A/B 模式: SERIAL, ||, 双引号, RETURNING
- alembic.py: Alembic 集成, M 兼容 MODIFY COLUMN 语法
- 连接串: gaussdb://user:pass@host:port/db?sslmode=disable

### 2. Python 3.7+ 兼容
- _oids.py: 加 from __future__ import annotations
- _tz.py: zoneinfo 兼容 backports.zoneinfo (3.7/3.8)
- pyproject.toml: requires-python >= 3.7, 加 3.7/3.8 classifiers

### 验证
- 78 个 gaussdb 包文件 + 3 个方言包文件全部 Python 3.7 语法兼容
- M 模式 DDL: id INTEGER NOT NULL AUTO_INCREMENT ✅
- M 模式 TIMESTAMP(6) ✅  
- M 模式 concat → CONCAT() ✅
- A 模式 DDL: id SERIAL NOT NULL ✅
- A 模式 concat → || ✅
- 连接串解析 ✅